### PR TITLE
Update Cordova plugin versions for appforms client template - FH-1576

### DIFF
--- a/www/config.json
+++ b/www/config.json
@@ -7,13 +7,13 @@
   },
   {
     "id": "org.apache.cordova.network-information",
-    "version": "0.2.7",
-    "url": "https://github.com/apache/cordova-plugin-network-information.git#r0.2.7"
+    "version": "0.2.9",
+    "url": "https://github.com/apache/cordova-plugin-network-information.git#r0.2.9"
   },
   {
     "id": "org.apache.cordova.geolocation",
-    "version": "0.3.6",
-    "url": "https://github.com/apache/cordova-plugin-geolocation.git#r0.3.6"
+    "version": "0.3.10",
+    "url": "https://github.com/apache/cordova-plugin-geolocation.git#r0.3.10"
   },
   {
     "id": "org.apache.cordova.file",
@@ -22,8 +22,8 @@
   },
   {
     "id": "org.apache.cordova.camera",
-    "version": "0.2.7",
-    "url": "https://github.com/apache/cordova-plugin-camera.git#r0.2.7"
+    "version": "0.3.2",
+    "url": "https://github.com/apache/cordova-plugin-camera.git#r0.3.2"
   },
   {
     "id": "com.phonegap.plugins.barcodescanner",


### PR DESCRIPTION
need to update geolocation and camera to work on at least iOS 8.2/8.3 devices