### PR TITLE
RHMAP-19011 - Cordova Forms App crashes on iOS 11 when using a PhotoCapture field

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -36,4 +36,7 @@
     <plugin name="cordova-plugin-console" spec="1.0.3" />
     <plugin name="fh-cordova-plugin-device" spec="https://github.com/feedhenry/fh-cordova-plugin-device.git#fh0.0.4" />
     <plugin name="cordova-plugin-whitelist" spec="1.2.2" />
+    <edit-config file="*-Info.plist" mode="merge" target="NSPhotoLibraryAddUsageDescription">
+        <string>Photo capture functionality needs access to photo library to save pictures.</string>
+    </edit-config>
 </widget>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feedhenry-appforms-template-app",
-  "version": "1.3.16",
+  "version": "1.3.17",
   "dependencies": {},
   "devDependencies": {
     "grunt-contrib-clean": "~0.5.0",


### PR DESCRIPTION
Task: https://issues.jboss.org/browse/RHMAP-19011

Following the steps to Test It:

1. Create a new project based on Form
2. Add a new client application by import
3. Import this branch 
4. Create a form with a photo capture field
5. deploy the form
6. Associate this for with the client app created based on this change
7. build the app for iOS and install on device
8. use the photo capture field to take a photo with the camera
9. select Use Photo and it should works 
10. Test the build and the camera for Android platform.