### PR TITLE
task(Rollback dep add via fhcap changes performed at RHMAP-1952): RHMAP-20694 - Remove fh-js-sdk add by mistake

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feedhenry-appforms-template-app",
-  "version": "1.3.17",
+  "version": "1.3.18",
   "dependencies": {
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "feedhenry-appforms-template-app",
   "version": "1.3.17",
   "dependencies": {
-    "fh-js-sdk": "~3.0.2"
   },
   "devDependencies": {
     "grunt-contrib-clean": "~0.5.0",


### PR DESCRIPTION
# JIRA
https://issues.jboss.org/browse/RHMAP-20694

# WHAT 
Remove the  fh-js-sdk dep

# WHY 
The  fh-js-sdk was added by mistake in a batch process to update in all projects this dep. 

