### PR TITLE
RHMAP-21003-v3.20: Add android 26 support for phonegap-plugin-barcodescanner to cordova template

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -29,7 +29,7 @@
     <plugin name="cordova-plugin-geolocation" spec="2.4.0" />
     <plugin name="cordova-plugin-file" spec="4.2.0" />
     <plugin name="cordova-plugin-camera" spec="2.3.0" />
-    <plugin name="phonegap-plugin-barcodescanner" spec="6.0.0" />
+    <plugin name="phonegap-plugin-barcodescanner" spec="https://github.com/feedhenry/phonegap-plugin-barcodescanner.git#6.0.0_with_android_support_26" />
     <plugin name="cordova-plugin-media" spec="2.4.0" />
     <plugin name="cordova-plugin-media-capture" spec="1.4.0" />
     <plugin name="cordova-plugin-file-transfer" spec="1.6.3" />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feedhenry-appforms-template-app",
-  "version": "1.3.17",
+  "version": "1.3.18",
   "dependencies": {},
   "devDependencies": {
     "grunt-contrib-clean": "~0.5.0",


### PR DESCRIPTION
# Jira link(s)
https://issues.jboss.org/browse/RHMAP-21003


# What
Add android 26 barcode scanner support

# Why
Apps won't build in the studio



# How
Change the phonegap-plugin-barcodescanner to point at a fork that supports android 26 as outline here https://issues.jboss.org/browse/RHMAP-20678


# Verification Steps
confirm that you can build cordova android application in the studio


## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member